### PR TITLE
fix(api): Remove temperature from o3-mini model

### DIFF
--- a/apps/api/src/app/chat/model.service.ts
+++ b/apps/api/src/app/chat/model.service.ts
@@ -111,7 +111,6 @@ const MODELS = {
       },
       configuration: {
         streaming: true,
-        temperature: 0,
       },
     },
     'gpt-4o-mini': {


### PR DESCRIPTION
**What?**
* Remove temperature from o3-mini model

**Why?**

* Temperature is not compatible with o3-mini model.