### PR TITLE
Increase node memory for Dockerfiles

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -20,6 +20,9 @@ RUN npm install -g pnpm@$PNPM_VERSION
 # Throw-away build stage to reduce size of final image
 FROM base AS build
 
+# Increase Node.js memory limit for build
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 # Install packages needed to build node modules
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -20,6 +20,9 @@ RUN npm install -g pnpm@$PNPM_VERSION
 # Throw-away build stage to reduce size of final image
 FROM base AS build
 
+# Increase Node.js memory limit for build
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 # Install packages needed to build node modules
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3


### PR DESCRIPTION
Increase Node.js memory limit in UI and API Dockerfiles to resolve build failures.

This addresses the "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory" error encountered during the Docker build.