### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -2,12 +2,8 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "main",
   "plugins": [
-    {
-      "plugin": "./tools/tsdown.plugin.ts"
-    },
-    {
-      "plugin": "./tools/copy-files-from-to.plugin.ts"
-    },
+    { "plugin": "./tools/tsdown.plugin.ts" },
+    { "plugin": "./tools/copy-files-from-to.plugin.ts" },
     {
       "plugin": "@nx/react/router-plugin",
       "options": {
@@ -19,12 +15,7 @@
         "typecheckTargetName": "typecheck"
       }
     },
-    {
-      "plugin": "@nx/playwright/plugin",
-      "options": {
-        "targetName": "e2e"
-      }
-    },
+    { "plugin": "@nx/playwright/plugin", "options": { "targetName": "e2e" } },
     {
       "plugin": "@nx/vite/plugin",
       "options": {
@@ -37,19 +28,11 @@
         "outputPath": "dist"
       }
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint",
-        "eslintConfig": "eslint.config.mjs"
-      }
-    },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint", "eslintConfig": "eslint.config.mjs" } },
     {
       "plugin": "@nx/js/typescript",
       "options": {
-        "typecheck": {
-          "targetName": "typecheck"
-        },
+        "typecheck": { "targetName": "typecheck" },
         "build": {
           "targetName": "typebuild",
           "configName": "tsconfig.lib.json",
@@ -60,36 +43,14 @@
     }
   ],
   "targetDefaults": {
-    "e2e-ci--**/*": {
-      "dependsOn": ["^build"]
-    },
-    "deploy": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "."
-      }
-    },
-    "launch": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "."
-      }
-    }
+    "e2e-ci--**/*": { "dependsOn": ["^build"] },
+    "deploy": { "executor": "nx:run-commands", "options": { "cwd": "." } },
+    "launch": { "executor": "nx:run-commands", "options": { "cwd": "." } }
   },
-  "generators": {
-    "@nx/react": {
-      "library": {
-        "unitTestRunner": "vitest"
-      }
-    }
-  },
-  "nxCloudId": "687b39d7852b9a43a8bba201",
-  "sync": {
-    "applyChanges": true
-  },
-  "tui": {
-    "enabled": false
-  },
+  "generators": { "@nx/react": { "library": { "unitTestRunner": "vitest" } } },
+  "nxCloudId": "69307979ae7522c0c5f02189",
+  "sync": { "applyChanges": true },
+  "tui": { "enabled": false },
   "namedInputs": {
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"],
     "default": ["{projectRoot}/**/*", "sharedGlobals"]


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/671e8f5a6ff0aaace54386a7/workspaces/69307979ae7522c0c5f02189

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `nx.json` to a compact format and sets a new `nxCloudId`.
> 
> - **Config (`nx.json`)**:
>   - Set new `nxCloudId` to `69307979ae7522c0c5f02189`.
>   - Compact inline formatting for plugin and target configurations (no functional option changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 482e869bd6b962b608b7546b54057668aaa40503. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->