### PR TITLE
fix(ui): Support missing analytics key

### DIFF
--- a/apps/ui/app/hooks/use-analytics.tsx
+++ b/apps/ui/app/hooks/use-analytics.tsx
@@ -10,8 +10,32 @@ export type Analytics = PostHog;
 
 export type ConsentStatus = 'pending' | 'granted' | 'denied';
 
+/**
+ * Noop analytics object that implements the PostHog interface.
+ * Used when PostHog is not configured (e.g., no API key in development or self-hosted).
+ */
+/* eslint-disable @typescript-eslint/naming-convention -- posthog-js uses snake_case method names */
+const noopAnalytics = {
+  opt_in_capturing: () => undefined,
+  opt_out_capturing: () => undefined,
+  get_explicit_consent_status: () => undefined,
+  identify: () => undefined,
+  reset: () => undefined,
+  _isIdentified: () => false,
+  captureException: () => undefined,
+} as unknown as Analytics;
+/* eslint-enable @typescript-eslint/naming-convention -- re-enable after noop object */
+
 export function useAnalytics(): Analytics {
   const posthog = usePostHog();
+
+  // When PostHog is not configured (no API key), usePostHog returns an object
+  // that doesn't have all the required methods. Check for a key method to determine
+  // if PostHog is properly initialized.
+  if (typeof posthog.get_explicit_consent_status !== 'function') {
+    return noopAnalytics;
+  }
+
   return posthog;
 }
 
@@ -79,7 +103,7 @@ export function AnalyticsProvider({ children }: { readonly children: React.React
 
   // When no API key is set, we don't use the analytics provider.
   // This is useful for development and self-hosted configurations.
-  // The usePostHog hook safely handles the missing context.
+  // The useAnalytics hook returns a noop implementation when PostHog is not available.
   if (!apiKey) {
     return children;
   }


### PR DESCRIPTION
Implement a noop analytics object in `useAnalytics` to prevent `TypeError` when PostHog is not initialized.

This fixes the `TypeError: analytics.get_explicit_consent_status is not a function` that occurred when the PostHog API key was not present in the environment, as `usePostHog` would return an object missing expected methods.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8008ce7-12b2-481e-a800-80bb87582184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8008ce7-12b2-481e-a800-80bb87582184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents runtime errors when PostHog isn’t configured by providing a safe fallback.
> 
> - Introduces `noopAnalytics` implementing required PostHog methods
> - Updates `useAnalytics` to detect missing `get_explicit_consent_status` and return the noop implementation
> - Adjusts provider comment to clarify noop behavior when no API key is set
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a94e0048029301ed39f7566003d29ada74a3f150. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced analytics stability with a defensive fallback mechanism when the analytics service is not fully configured, ensuring the app continues to function without interruption.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->