### PR TITLE
fix(ui): Clear kernel error when applying file edit

### DIFF
--- a/apps/ui/app/hooks/use-chat-tools.tsx
+++ b/apps/ui/app/hooks/use-chat-tools.tsx
@@ -67,18 +67,9 @@ export function useChatTools(): UseChatToolsReturn {
 
           await fileManager.writeFile(resolvedPath, encodeTextFile(result.editedContent), { source: 'external' });
 
-          // Clear stale code errors immediately after file write.
-          // Monaco validation runs asynchronously and may not complete before CAD processing finishes,
-          // which would cause us to return outdated errors to the LLM.
-          // Clearing ensures we don't waste LLM tokens on non-existent issues.
-          cadActor.send({ type: 'setCodeErrors', errors: [] });
-
-          // Clear stale kernel errors for the file being edited.
-          // Old kernel errors from a previous file state would cause false positives
-          // if they remain while new CAD processing is running.
-          cadActor.send({ type: 'clearKernelErrors', filename: resolvedPath });
-
-          // Wait for CAD processing to complete
+          // Wait for CAD processing to complete.
+          // Note: Stale code and kernel errors are cleared atomically by the CAD machine
+          // when it receives the setFile event triggered by the file write.
           const cadSnapshot = await waitFor(cadActor, (state) => state.value === 'ready' || state.value === 'error');
 
           // Get the kernel errors for the edited file from the per-file errors map

--- a/apps/ui/app/machines/cad.machine.ts
+++ b/apps/ui/app/machines/cad.machine.ts
@@ -39,7 +39,6 @@ type CadEvent =
   | { type: 'setFile'; file: GeometryFile }
   | { type: 'setParameters'; parameters: Record<string, unknown> }
   | { type: 'setCodeErrors'; errors: CadContext['codeErrors'] }
-  | { type: 'clearKernelErrors'; filename: string }
   | { type: 'exportGeometry'; format: ExportFormat }
   | KernelEventExternal;
 
@@ -120,6 +119,16 @@ export const cadMachine = setup({
         assertEvent(event, 'setFile');
         return event.file;
       },
+      // Clear stale errors atomically when file changes.
+      // Old errors become invalid when content changes, and new errors
+      // will be set by kernel processing or Monaco validation.
+      codeErrors: () => [],
+      kernelErrors({ context, event }) {
+        assertEvent(event, 'setFile');
+        const newErrorsMap = new Map(context.kernelErrors);
+        newErrorsMap.delete(event.file.filename);
+        return newErrorsMap;
+      },
     }),
     setParameters: assign({
       parameters({ event }) {
@@ -187,14 +196,6 @@ export const cadMachine = setup({
       codeErrors({ event }) {
         assertEvent(event, 'setCodeErrors');
         return event.errors;
-      },
-    }),
-    clearKernelErrors: assign({
-      kernelErrors({ context, event }) {
-        assertEvent(event, 'clearKernelErrors');
-        const newErrorsMap = new Map(context.kernelErrors);
-        newErrorsMap.delete(event.filename);
-        return newErrorsMap;
       },
     }),
     setDefaultParameters: assign({
@@ -412,9 +413,6 @@ export const cadMachine = setup({
         setCodeErrors: {
           actions: 'setCodeErrors',
         },
-        clearKernelErrors: {
-          actions: 'clearKernelErrors',
-        },
         exportGeometry: {
           actions: 'exportGeometry',
         },
@@ -546,9 +544,6 @@ export const cadMachine = setup({
         setCodeErrors: {
           actions: 'setCodeErrors',
         },
-        clearKernelErrors: {
-          actions: 'clearKernelErrors',
-        },
         exportGeometry: {
           actions: 'exportGeometry',
         },
@@ -585,9 +580,6 @@ export const cadMachine = setup({
         },
         setCodeErrors: {
           actions: 'setCodeErrors',
-        },
-        clearKernelErrors: {
-          actions: 'clearKernelErrors',
         },
         exportGeometry: {
           actions: 'exportGeometry',


### PR DESCRIPTION
Clear kernel errors when applying code changes to prevent false positives.

---
<a href="https://cursor.com/background-agent?bcId=bc-21326455-bb0f-454e-b8a9-f8c00ab29fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21326455-bb0f-454e-b8a9-f8c00ab29fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures per-file kernel errors are cleared immediately after code edits to avoid stale error reports during CAD processing.
> 
> - Adds `clearKernelErrors` event/action to `cad.machine.ts` to delete a file’s entry from the `kernelErrors` map; wired in `ready`, `rendering`, and `error` states and included in event typings
> - `use-chat-tools.tsx`: after writing edited content, sends `setCodeErrors([])` and `clearKernelErrors` for the edited file, then waits for CAD and returns that file’s kernel errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d00c9863a0f5d1be7b66c031e3fb6edee60b24de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clearing of per-file code and kernel errors to prevent stale errors after edits; errors are now purged atomically when switching or updating files, eliminating redundant stale-error displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->