### PR TITLE
fix(root): Parameterize create-repo CI runners

### DIFF
--- a/.agents/skills/create-repo/SKILL.md
+++ b/.agents/skills/create-repo/SKILL.md
@@ -54,7 +54,7 @@ Bind all values before copying files:
 | Vale pack        | Default `Tau`                                         |
 | docs site        | `yes` or `no`                                         |
 | benchmark axes   | Bytes always; wall-clock optional                     |
-| host matrix      | Exact Node, browser, native OS, and GPU legs          |
+| host matrix      | Exact Node, browser runner, native OS, and GPU legs   |
 
 Template tokens use the collision-free form `@@CREATE_REPO_<name>@@`. Replace
 only those tokens; GitHub expressions and ESLint `{{term}}` messages are not

--- a/.agents/skills/create-repo/SKILL.md
+++ b/.agents/skills/create-repo/SKILL.md
@@ -164,6 +164,8 @@ the npm Trusted Publisher identity.
    every clean consumer job. Publish platform packages before the root package.
    Prefix local `npm/` package paths with `./` so npm cannot resolve them as
    registry or Git shorthands. Do not rebuild in consumer or publish jobs.
+   Bind browser runners and headless modes that expose every required platform
+   capability; API presence without a usable adapter is not a passing smoke.
 4. Publish idempotently through OIDC. If the version exists, compare registry
    bytes and provenance instead of overwriting it.
 5. `registry-verify` installs from the registry and checks the provenance

--- a/.agents/skills/create-repo/repo-checklist.md
+++ b/.agents/skills/create-repo/repo-checklist.md
@@ -62,6 +62,7 @@ Applicability:
 | R    | Local platform package paths passed to npm begin with `./`.                                                                   |
 | R    | Every host/consumer job downloads and tests that candidate without rebuilding it.                                             |
 | R    | Candidate and consumer jobs run the bound host setup before executing host-dependent code.                                    |
+| R    | Browser jobs prove required adapters are usable on their bound runner and headless mode.                                      |
 | R    | Publish job has `id-token: write`, no checkout, no registry token, and is idempotent.                                         |
 | R    | Existing registry versions are byte/provenance verified rather than overwritten.                                              |
 | R    | Registry verification installs by exact version and checks package, source repo, workflow, commit, integrity, and provenance. |

--- a/.agents/skills/create-repo/templates/ci.yml
+++ b/.agents/skills/create-repo/templates/ci.yml
@@ -179,6 +179,7 @@ jobs:
       - run: '@@CREATE_REPO_clean-room-consumer-command@@'
 
   browser:
+    name: browser (${{ matrix.browser }})
     needs: candidate
     strategy:
       fail-fast: false

--- a/.agents/skills/create-repo/templates/ci.yml
+++ b/.agents/skills/create-repo/templates/ci.yml
@@ -183,8 +183,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium, firefox, webkit]
-    runs-on: ubuntu-latest
+        include:
+          - browser: chromium
+            os: '@@CREATE_REPO_chromium-runner@@'
+          - browser: firefox
+            os: '@@CREATE_REPO_firefox-runner@@'
+          - browser: webkit
+            os: '@@CREATE_REPO_webkit-runner@@'
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.agents/skills/create-repo/templates/ci.yml
+++ b/.agents/skills/create-repo/templates/ci.yml
@@ -91,13 +91,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: '@@CREATE_REPO_linux-runner@@'
             gpu-setup: '@@CREATE_REPO_linux-gpu-setup@@'
             artifact: linux-x64-gnu
-          - os: macos-latest
+          - os: '@@CREATE_REPO_macos-runner@@'
             gpu-setup: '@@CREATE_REPO_macos-gpu-setup@@'
             artifact: darwin-arm64
-          - os: windows-latest
+          - os: '@@CREATE_REPO_windows-runner@@'
             gpu-setup: '@@CREATE_REPO_windows-gpu-setup@@'
             artifact: win32-x64-msvc
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- bind explicit runner versions for every native and browser leg in the create-repo CI template
- keep host selection inside the documented host-matrix parameter contract

## Verification
- actionlint after binding nanoraster’s proven Ubuntu 24.04, macOS 14, and Windows 2022 values
- git diff --check

## Context
The first nanoraster CI run proved Playwright’s Linux Firefox and WebKit builds do not expose usable WebGPU adapters; the identical real-render tests pass on macOS. This preserves all three mandatory engine tests without skips or mocks and prevents `-latest` runner drift across native legs.