### PR TITLE
fix(create-repo): preserve release intent

### DIFF
--- a/.agents/skills/create-repo/SKILL.md
+++ b/.agents/skills/create-repo/SKILL.md
@@ -140,9 +140,10 @@ tests together.
 
 1. Use one root project with `nx:run-commands` targets, toolchain fingerprints
    in `namedInputs`, and a fan-in `quality` target.
-2. Configure `nx release` with Version Plans and git-inert settings: Nx mutates
-   files; CI owns commits, tags, pushes, registries, and releases. Root and
-   platform packages form one fixed release group.
+2. Configure `nx release` with Version Plans,
+   `adjustSemverBumpsForZeroMajorVersion: false`, and git-inert settings: Nx
+   mutates files; CI owns commits, tags, pushes, registries, and releases. Root
+   and platform packages form one fixed release group.
 3. Copy `prepare-release.mjs`, `ci-release.mjs`, their tests, and the repo-local
    `release-@@CREATE_REPO_slug@@` skill. Keep release policy pure and unit tested.
 4. The sole automatic publish trigger is the exact commit subject

--- a/.agents/skills/create-repo/repo-checklist.md
+++ b/.agents/skills/create-repo/repo-checklist.md
@@ -41,7 +41,7 @@ Applicability:
 | ---- | ---------------------------------------------------------------------------------------------------------------- |
 | R    | One root Nx project uses `nx:run-commands`; `quality` fans into every gate.                                      |
 | R    | `namedInputs` include runtime and native toolchain fingerprints.                                                 |
-| R    | Nx Release uses Version Plans and git-inert settings.                                                            |
+| R    | Nx Release uses Version Plans, standard pre-1.0 SemVer bumps, and git-inert settings.                            |
 | R    | Version-plan checks ignore only tests, docs, and governance paths that cannot change the package.                |
 | R    | `prepare-release.mjs` validates requested versus planned version.                                                |
 | R    | Release policy is a pure module with unit tests for PR, main, manual, and malformed release commits.             |

--- a/.agents/skills/create-repo/templates/ci.yml
+++ b/.agents/skills/create-repo/templates/ci.yml
@@ -30,10 +30,10 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref }}
-          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           if [[ "$EVENT_NAME" == pull_request ]]; then
-            git diff --name-only --diff-filter=ACDMRT "origin/$BASE_REF...HEAD" > /tmp/changed-files
+            git diff --name-only --diff-filter=ACDMRT "origin/$BASE_REF...$SOURCE_SHA" > /tmp/changed-files
           else
             git diff-tree --no-commit-id --name-only --diff-filter=ACDMRT -r HEAD > /tmp/changed-files
           fi
@@ -42,7 +42,7 @@ jobs:
             --ref "$REF_NAME" \
             --sha "$SOURCE_SHA" \
             --package-version "$(node -p "require('./package.json').version")" \
-            --subject "$(git log -1 --pretty=%s)" \
+            --subject "$(git log -1 --pretty=%s "$SOURCE_SHA")" \
             --changed-files-file /tmp/changed-files
 
   quality:

--- a/.agents/skills/create-repo/templates/ci.yml
+++ b/.agents/skills/create-repo/templates/ci.yml
@@ -17,6 +17,7 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     outputs:
+      kind: ${{ steps.release.outputs.kind }}
       npm-publish: ${{ steps.release.outputs.npm_publish }}
       version: ${{ steps.release.outputs.version }}
     steps:
@@ -50,12 +51,25 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup
         with:
           node-version: '@@CREATE_REPO_node-latest@@'
       - run: pnpm nx run @@CREATE_REPO_slug@@:quality
       - run: node --test tests/ci/ci-release.test.mjs tests/ci/release-attestations.test.mjs
+      - name: Require a Version Plan for release-affecting changes
+        if: needs.preflight.outputs.kind != 'release-pull-request' && needs.preflight.outputs.kind != 'release'
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT_NAME" == pull_request ]]; then
+            pnpm nx release plan:check --base="origin/$BASE_REF" --head=HEAD
+          else
+            pnpm nx release plan:check --base=HEAD~1 --head=HEAD
+          fi
 
   docs-prose:
     needs: preflight

--- a/.agents/skills/create-repo/templates/ci.yml
+++ b/.agents/skills/create-repo/templates/ci.yml
@@ -63,10 +63,21 @@ jobs:
         shell: bash
         env:
           BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           if [[ "$EVENT_NAME" == pull_request ]]; then
             pnpm nx release plan:check --base="origin/$BASE_REF" --head=HEAD
+          elif [[ "$EVENT_NAME" == push ]]; then
+            if [[ "$BEFORE_SHA" == 0000000000000000000000000000000000000000 ]]; then
+              echo "::error::Cannot validate Version Plans without a previous push SHA"
+              exit 1
+            fi
+            git merge-base --is-ancestor "$BEFORE_SHA" HEAD || {
+              echo "::error::Cannot validate Version Plans across a force-push"
+              exit 1
+            }
+            pnpm nx release plan:check --base="$BEFORE_SHA" --head=HEAD
           else
             pnpm nx release plan:check --base=HEAD~1 --head=HEAD
           fi

--- a/.agents/skills/create-repo/templates/nx.json
+++ b/.agents/skills/create-repo/templates/nx.json
@@ -15,6 +15,7 @@
     "projectsRelationship": "fixed",
     "version": {
       "specifierSource": "version-plans",
+      "adjustSemverBumpsForZeroMajorVersion": false,
       "preVersionCommand": "pnpm nx run @@CREATE_REPO_slug@@:quality"
     },
     "versionPlans": {

--- a/.agents/skills/create-repo/templates/release-skill/SKILL.md
+++ b/.agents/skills/create-repo/templates/release-skill/SKILL.md
@@ -31,6 +31,8 @@ Reject other arguments.
 5. Require changes only to `package.json`, `pnpm-lock.yaml`, `CHANGELOG.md`, and
    consumed `.nx/version-plans/*.md` files.
 6. Run `pnpm nx run @@CREATE_REPO_slug@@:quality` and `git diff --check`.
+   The dry-run proves the Version Plan before generation; the release policy
+   validates that the generated commit consumes it.
 7. For submit, commit exactly `chore(release): @@CREATE_REPO_slug@@ v<version>`, push, and
    open a pull request describing the package, version, plan, and validations.
 

--- a/.agents/skills/create-repo/templates/scripts/check-prose.sh
+++ b/.agents/skills/create-repo/templates/scripts/check-prose.sh
@@ -9,10 +9,16 @@ repo_root="$(cd "$script_dir/.." && pwd)"
 "$script_dir/install-ci-tool.sh" --tool vale --dest "$repo_root/.ci-tools"
 
 cd "$repo_root"
-git ls-files -z \
-  '*.md' \
-  '*.mdx' \
-  ':!rust/vendor/**' \
-  | xargs -0 .ci-tools/bin/vale --config=.vale.ini
+prose_files=()
+while IFS= read -r -d '' file; do
+  [[ -f "$file" ]] && prose_files+=("$file")
+done < <(
+  git ls-files -z \
+    '*.md' \
+    '*.mdx' \
+    ':!rust/vendor/**'
+)
+
+.ci-tools/bin/vale --config=.vale.ini "${prose_files[@]}"
 
 pnpm exec vitest run prose-quality.test.ts readme-shape.test.ts

--- a/.agents/skills/create-repo/templates/scripts/check-prose.sh
+++ b/.agents/skills/create-repo/templates/scripts/check-prose.sh
@@ -9,15 +9,18 @@ repo_root="$(cd "$script_dir/.." && pwd)"
 "$script_dir/install-ci-tool.sh" --tool vale --dest "$repo_root/.ci-tools"
 
 cd "$repo_root"
+prose_list="$(mktemp)"
+trap 'rm -f "$prose_list"' EXIT
+git ls-files -z \
+  '*.md' \
+  '*.mdx' \
+  ':!rust/vendor/**' \
+  > "$prose_list"
+
 prose_files=()
 while IFS= read -r -d '' file; do
   [[ -f "$file" ]] && prose_files+=("$file")
-done < <(
-  git ls-files -z \
-    '*.md' \
-    '*.mdx' \
-    ':!rust/vendor/**'
-)
+done < "$prose_list"
 
 .ci-tools/bin/vale --config=.vale.ini "${prose_files[@]}"
 


### PR DESCRIPTION
## Summary
- preserve standard pre-1.0 SemVer intent in generated repositories
- keep Version Plan validation on ordinary PRs and main pushes while allowing a validated release commit to consume its plan
- exclude consumed plan files from generated prose checks

## Validation
- workspace oxfmt check
- bash syntax check for the prose template
- git diff --check
- nanoraster PR #10 exercises the rendered workflow end to end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Standardized version bump behavior for pre-1.0 releases.
  * Added validation to confirm release plans are reviewed and consumed correctly.
  * Improved release checks while preserving existing version-plan and publishing workflows.

* **CI Improvements**
  * Pull requests now validate release plans against the appropriate base revision.
  * Release-specific workflows continue to bypass checks when appropriate.

* **Documentation**
  * Updated repository setup and release guidance to reflect the revised policies.

* **Quality Improvements**
  * Improved Markdown and MDX prose checking, including safer handling of excluded and non-file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->