### PR TITLE
ci(root): scope release bot token to main

### DIFF
--- a/.github/workflows/prepare-prod-release.yml
+++ b/.github/workflows/prepare-prod-release.yml
@@ -43,7 +43,7 @@ jobs:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ github.repository }}
+          repositories: ${{ github.event.repository.name }}
           permission-contents: write
           permission-pull-requests: write
 

--- a/.github/workflows/prepare-prod-release.yml
+++ b/.github/workflows/prepare-prod-release.yml
@@ -32,6 +32,9 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment:
+      name: release-pr
+      deployment: false
     steps:
       - name: Mint tau-release-bot token
         id: release-bot-token
@@ -39,6 +42,10 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.repository }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Limit Tau release workflow to the release-pr environment and mint a token for only this repository. The environment and secrets are already provisioned by cloud-infra.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production release preparation workflow to use a dedicated release environment.
  * Improved release automation permissions and repository scoping for safer workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->