### PR TITLE
chore(root): adopt three-viewport-gizmo v2.2.3

### DIFF
--- a/license-deps
+++ b/license-deps
@@ -23,7 +23,7 @@ Distributions that exclude `@taucad/openscad` carry no GPL obligation.
 
 By using Tau, you agree to comply with the license terms of all included dependencies.
 
-*Generated on 2026-08-15*
+*Generated on 2026-08-26*
 
 ## Summary
 
@@ -275,6 +275,7 @@ By using Tau, you agree to comply with the license terms of all included depende
 - **@taucad/replicad-opencascadejs** v0.23.0-beta.0 — [Repository](https://github.com/taucad/replicad)
 - **@taucad/runtime** v0.1.0-beta.1 — [Repository](https://github.com/taucad/tau)
 - **@taucad/utils** v0.1.0-beta.0 — [Repository](https://github.com/taucad/tau)
+- **@taulabs/three-viewport-gizmo** v2.2.3 — [Repository](https://github.com/taucad/three-viewport-gizmo)
 - **@testing-library/jest-dom** v6.6.3 — [Repository](https://github.com/testing-library/jest-dom)
 - **@testing-library/react** v16.2.0 — [Repository](https://github.com/testing-library/react-testing-library)
 - **@testing-library/user-event** v14.6.1 — [Repository](https://github.com/testing-library/user-event)
@@ -415,7 +416,6 @@ By using Tau, you agree to comply with the license terms of all included depende
 - **tailwindcss** v4.3.0 — [Repository](https://github.com/tailwindlabs/tailwindcss)
 - **three** v0.184.0 — [Repository](https://github.com/mrdoob/three.js)
 - **three-mesh-bvh** v0.9.10 — [Repository](https://github.com/gkjohnson/three-mesh-bvh)
-- **three-viewport-gizmo** v2.2.2-tau.2 — [Repository](https://github.com/Fennec-hub/three-viewport-gizmo)
 - **ts-node** v10.9.2 — [Repository](https://github.com/TypeStrong/ts-node)
 - **tsdown** v0.15.12 — [Repository](https://github.com/rolldown/tsdown)
 - **tsx** v4.22.3 — [Repository](https://github.com/privatenumber/tsx)

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "tailwind-merge": "^3.6.0",
     "three": "^0.184.0",
     "three-mesh-bvh": "^0.9.10",
-    "three-viewport-gizmo": "file:tarballs/three-viewport-gizmo-fork/three-viewport-gizmo-2.2.2-tau.2.tgz",
+    "three-viewport-gizmo": "npm:@taulabs/three-viewport-gizmo@2.2.3",
     "tslib": "catalog:",
     "turndown": "catalog:",
     "typescript-eslint": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1225,8 +1225,8 @@ importers:
         specifier: ^0.9.10
         version: 0.9.10(three@0.184.0)
       three-viewport-gizmo:
-        specifier: file:tarballs/three-viewport-gizmo-fork/three-viewport-gizmo-2.2.2-tau.2.tgz
-        version: file:tarballs/three-viewport-gizmo-fork/three-viewport-gizmo-2.2.2-tau.2.tgz(three@0.184.0)
+        specifier: npm:@taulabs/three-viewport-gizmo@2.2.3
+        version: '@taulabs/three-viewport-gizmo@2.2.3(three@0.184.0)'
       tslib:
         specifier: 'catalog:'
         version: 2.8.1
@@ -10777,6 +10777,11 @@ packages:
 
   '@taucad/replicad@0.23.3-beta.1':
     resolution: {integrity: sha512-ho9deRCHLx6PuRYYDP4KZ60+7KroxSlIOqXH86Rco3fedq1Hes75+eUYsMAhi3A72tt+UdITQHcD4iDu+xyzUQ==}
+
+  '@taulabs/three-viewport-gizmo@2.2.3':
+    resolution: {integrity: sha512-+/Lo5FsmRXDtMLqQZQzGhPKnptl6wF76VVVUBTOdQLo6x7OTZdEypTRRsd0M/xumEp2pOez2q809jgYVd7bA0A==}
+    peerDependencies:
+      three: '>=0.162.0 <1.0.0'
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -21265,12 +21270,6 @@ packages:
     resolution: {integrity: sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==}
     peerDependencies:
       three: '>=0.128.0'
-
-  three-viewport-gizmo@file:tarballs/three-viewport-gizmo-fork/three-viewport-gizmo-2.2.2-tau.2.tgz:
-    resolution: {integrity: sha512-zoxtA7gFZSacWB1YHpD4Xh2avx0YFUuVXShJ8iWt0UjgtMVV8RFwf3L9PgAQPtrdUlY4hhvCFUnoq2y+SxB2Pg==, tarball: file:tarballs/three-viewport-gizmo-fork/three-viewport-gizmo-2.2.2-tau.2.tgz}
-    version: 2.2.2-tau.2
-    peerDependencies:
-      three: '>=0.162.0 <1.0.0'
 
   three@0.184.0:
     resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
@@ -31914,6 +31913,10 @@ snapshots:
       flatbush: 4.5.0
       opentype.js: 1.3.4
       replicad-opencascadejs: '@taucad/replicad-opencascadejs@0.23.0-beta.0'
+
+  '@taulabs/three-viewport-gizmo@2.2.3(three@0.184.0)':
+    dependencies:
+      three: 0.184.0
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -44985,10 +44988,6 @@ snapshots:
       draco3d: 1.5.7
       fflate: 0.6.10
       potpack: 1.0.2
-      three: 0.184.0
-
-  three-viewport-gizmo@file:tarballs/three-viewport-gizmo-fork/three-viewport-gizmo-2.2.2-tau.2.tgz(three@0.184.0):
-    dependencies:
       three: 0.184.0
 
   three@0.184.0: {}

--- a/repos.yaml
+++ b/repos.yaml
@@ -466,7 +466,7 @@ repos:
     upstream: Fennec-hub/three-viewport-gizmo
     description: Three Viewport Gizmo - interactive three.js view helper
     fork: taucad/three-viewport-gizmo
-    commit: af81ccf4923343d0f285300e9b230390b673e5dd
+    commit: bbad36f3e1a2b80650a9d31831c8b1bb7443eefb
   terraform-provider-netlify:
     upstream: netlify/terraform-provider-netlify
     description: Netlify Terraform provider source (schema/release reference for Tau cloud-infra stacks).


### PR DESCRIPTION
## Summary

- replace the vendored three-viewport-gizmo tarball with the trusted-published @taulabs/three-viewport-gizmo 2.2.3 release
- pin repos.yaml to the exact annotated-release commit
- retain the verified npm integrity in pnpm-lock.yaml
- regenerate license-deps so the scoped package name, version, and repository replace the old unscoped fork entry

## Validation

- PASS: pnpm license-deps:validate
- PASS: pnpm nx test ui --watch=false app/components/geometry/graphics/three/controls/viewport-gizmo-cube-axes.test.ts (2 tests)
- PASS: pnpm nx lint ui --files=app/components/geometry/graphics/three/controls/**
- PASS: production client and server build through the ui-e2e dependency graph
- PASS: browser acceptance on the production build: Top settles left-to-right with byte-identical completion/post-settle frames, controls orbit afterward, repeated Top and Bottom settle correctly
- BASELINE: pnpm nx typecheck ui reports nine existing errors in code-editor.client.tsx and dockview files, outside this dependency-only diff
- BASELINE: graphics-backend.spec.ts targets removed /projects/proj_birdhouse/preview fixture and receives the application 404 before WebGPU/gizmo assertions
- BASELINE: repository-wide CI also reports pre-existing formatting/frontmatter, bundle-size, API smoke, lint, typecheck, and unrelated test failures; the dependency-generated license gate passes

Release: https://github.com/taucad/three-viewport-gizmo/releases/tag/v2.2.3
Publish run: https://github.com/taucad/three-viewport-gizmo/actions/runs/32974605589