### PR TITLE
feat(geometry-core): preserve exact manifold topology

### DIFF
--- a/packages/core/geometry/README.md
+++ b/packages/core/geometry/README.md
@@ -48,15 +48,17 @@ const exported = await transformGltfExportBytes(named, {
 
 ## API
 
-| Area                            | Exports                                                                                                                                                        |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| glTF extension contract         | `allExtensions`, `registerTauGltfExtensions`, `TauCadTopology`, `TauCadTopologyRoot`, `KittyCadBoundaryRepresentation`, `KittyCadBrepNode`, `KittyCadBrepRoot` |
-| glTF IO and document transforms | `createNodeIo`, `createCoordinateTransform`, `createScalingTransform`, `createReverseCoordinateTransform`                                                      |
-| Serialized-bytes pipeline       | `normalizeGltfGeometryNames`, `transformGltfExportBytes`                                                                                                       |
-| GLB writing                     | `writeGlb`, `writeGltfJson`, `createEmptyGlb`, `createEmptyGltf`, `createEmptyGltfGeometry`, types `GlbInput`, `GlbNode`, `GlbPrimitive`, `GlbMaterial`        |
-| Import staging                  | `createImportFileInventory`, `ImportLoader`, types `ImportFile`, `ImportFileInventory`, `FileResolver`                                                         |
-| Names and color                 | `resolveShapeName`, `uniqueShapeName`, `formatShapeName`, `isLegacyGeneratedShapeName`, `srgbToLinear`, `srgbTupleToLinear`, `srgbHexToLinearTuple`            |
-| Coordinate and unit transforms  | `transformVertexArray`, `transformNormalArray`, types `GeometryOutputTransformOptions`, `OutputCoordinateSystem`, `OutputLengthUnit`                           |
+| Area                            | Exports                                                                                                                                                                        |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| glTF extension contract         | `allExtensions`, `registerTauGltfExtensions`, `TauCadTopology`, `TauCadTopologyRoot`, `KittyCadBoundaryRepresentation`, `KittyCadBrepNode`, `KittyCadBrepRoot`                 |
+| glTF IO and document transforms | `createNodeIo`, `createCoordinateTransform`, `createScalingTransform`, `createReverseCoordinateTransform`                                                                      |
+| Serialized-bytes pipeline       | `normalizeGltfGeometryNames`, `transformGltfExportBytes`                                                                                                                       |
+| GLB writing                     | `writeGlb`, `writeGltfJson`, `createEmptyGlb`, `createEmptyGltf`, `createEmptyGltfGeometry`, types `GlbInput`, `GlbNode`, `GlbPrimitive`, `GlbMaterial`, `GlbManifoldTopology` |
+| Import staging                  | `createImportFileInventory`, `ImportLoader`, types `ImportFile`, `ImportFileInventory`, `FileResolver`                                                                         |
+| Names and color                 | `resolveShapeName`, `uniqueShapeName`, `formatShapeName`, `isLegacyGeneratedShapeName`, `srgbToLinear`, `srgbTupleToLinear`, `srgbHexToLinearTuple`                            |
+| Coordinate and unit transforms  | `transformVertexArray`, `transformNormalArray`, types `GeometryOutputTransformOptions`, `OutputCoordinateSystem`, `OutputLengthUnit`                                           |
+
+The shared glTF-Transform registry preserves `EXT_mesh_manifold`.
 
 | Entry                   | Purpose                                                                                     |
 | ----------------------- | ------------------------------------------------------------------------------------------- |

--- a/packages/core/geometry/package.json
+++ b/packages/core/geometry/package.json
@@ -55,7 +55,8 @@
   "dependencies": {
     "@gltf-transform/core": "catalog:",
     "@gltf-transform/extensions": "catalog:",
-    "@gltf-transform/functions": "catalog:"
+    "@gltf-transform/functions": "catalog:",
+    "manifold-3d": "catalog:"
   },
   "peerDependencies": {
     "@taucad/runtime": "^0.1.0-beta.0"

--- a/packages/core/geometry/src/extensions/registry.ts
+++ b/packages/core/geometry/src/extensions/registry.ts
@@ -1,14 +1,16 @@
 import type { Extension, PlatformIO } from '@gltf-transform/core';
+import { EXTManifold } from 'manifold-3d/manifold-gltf';
 import { FbNgonEncodingExtension } from '#extensions/fb-ngon-encoding.js';
 import { KittyCadBoundaryRepresentation } from '#extensions/kittycad-boundary-representation.js';
 import { TauCadTopology } from '#extensions/tau-cad-topology.js';
 
 /**
- * Tau-supported non-Khronos glTF-Transform extensions.
+ * Extensions preserved by Tau glTF-Transform pipelines.
  *
  * @public
  */
 export const tauCadGltfExtensions = [
+  EXTManifold,
   KittyCadBoundaryRepresentation,
   TauCadTopology,
   FbNgonEncodingExtension,

--- a/packages/core/geometry/src/index.ts
+++ b/packages/core/geometry/src/index.ts
@@ -39,7 +39,7 @@ export {
   writeGlb,
   writeGltfJson,
 } from '#utils/glb-writer.js';
-export type { GlbInput, GlbMaterial, GlbNode, GlbPrimitive } from '#utils/glb-writer.js';
+export type { GlbInput, GlbManifoldTopology, GlbMaterial, GlbNode, GlbPrimitive } from '#utils/glb-writer.js';
 
 // Names
 export { formatShapeName, isLegacyGeneratedShapeName, resolveShapeName, uniqueShapeName } from '#utils/shape-names.js';

--- a/packages/core/geometry/src/utils/glb-writer.test.ts
+++ b/packages/core/geometry/src/utils/glb-writer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { NodeIO } from '@gltf-transform/core';
+import { EXTManifold } from 'manifold-3d/manifold-gltf';
 import {
   createEmptyGlb,
   createEmptyGltf,
@@ -76,6 +77,33 @@ function createLinesInput(): GlbInput {
           },
         ],
       },
+    ],
+  };
+}
+
+const cubeIndices = new Uint32Array([
+  0, 2, 1, 0, 3, 2, 4, 5, 6, 4, 6, 7, 0, 1, 5, 0, 5, 4, 3, 7, 6, 3, 6, 2, 0, 4, 7, 0, 7, 3, 1, 2, 6, 1, 6, 5,
+]);
+
+function createManifoldInput(): GlbInput {
+  const basePositions = [-1, -1, -1, 1, -1, -1, 1, 1, -1, -1, 1, -1, -1, -1, 1, 1, -1, 1, 1, 1, 1, -1, 1, 1];
+  const positions = new Float32Array([...basePositions, ...basePositions]);
+  const normals = new Float32Array(positions.length);
+  const first = cubeIndices.filter((_, index) => Math.floor(index / 3) % 2 === 0);
+  const second = cubeIndices.filter((_, index) => Math.floor(index / 3) % 2 === 1).map((index) => index + 8);
+  const exact = new Uint32Array([...first, ...second.map((index) => index - 8)]);
+  const { material } = createTrianglePrimitive();
+  return {
+    nodes: [
+      {
+        name: 'Surface',
+        primitives: [
+          { mode: 4, positions, normals, indices: first, material },
+          { mode: 4, positions, normals, indices: second, material: { ...material, baseColorFactor: [1, 0, 0, 1] } },
+        ],
+        manifoldTopology: { indices: exact },
+      },
+      createLinesInput().nodes[0]!,
     ],
   };
 }
@@ -307,6 +335,46 @@ describe('writeGlb', () => {
     expect(positions.getCount()).toBe(4);
 
     expect(primitive.getAttribute('NORMAL')).toBeNull();
+  });
+
+  it('should serialize certified manifold topology and keep lines in a sibling mesh', async () => {
+    const glb = writeGlb(createManifoldInput());
+    const json = readGlbJson(glb) as {
+      extensionsUsed: string[];
+      meshes: Array<{
+        extensions?: {
+          EXT_mesh_manifold?: { manifoldPrimitive: { indices: number }; mergeIndices: number; mergeValues: number };
+        };
+        primitives: Array<{ attributes: Record<string, number>; indices: number }>;
+      }>;
+      accessors: Array<{ bufferView: number; byteOffset: number; count: number; sparse?: { count: number } }>;
+    };
+    const surface = json.meshes[0]!;
+    const extension = surface.extensions?.EXT_mesh_manifold;
+
+    expect(json.extensionsUsed).toContain('EXT_mesh_manifold');
+    expect(surface.primitives[0]!.attributes).toEqual(surface.primitives[1]!.attributes);
+    expect(json.accessors[surface.primitives[0]!.indices]!.bufferView).toBe(
+      json.accessors[surface.primitives[1]!.indices]!.bufferView,
+    );
+    expect(json.accessors[surface.primitives[1]!.indices]!.byteOffset).toBe(18 * Uint32Array.BYTES_PER_ELEMENT);
+    expect(json.accessors[extension!.manifoldPrimitive.indices]!.sparse?.count).toBe(18);
+    expect(typeof extension?.mergeIndices).toBe('number');
+    expect(typeof extension?.mergeValues).toBe('number');
+    expect(json.meshes[1]!.extensions).toBeUndefined();
+
+    const document = await new NodeIO().registerExtensions([EXTManifold]).readBinary(glb);
+    expect(document.getRoot().listMeshes()[0]!.getExtension(EXTManifold.EXTENSION_NAME)).not.toBeNull();
+  });
+
+  it('should refuse false manifold claims at the writer boundary', () => {
+    const input = createSingleTriangleInput();
+    input.nodes[0]!.manifoldTopology = { indices: new Uint32Array([0, 1, 2]) };
+    expect(() => writeGlb(input)).toThrow('not an oriented 2-manifold');
+
+    const mismatched = createManifoldInput();
+    mismatched.nodes[0]!.manifoldTopology!.indices[18] = 6;
+    expect(() => writeGlb(mismatched)).toThrow('identical POSITION values');
   });
 
   it('should produce correct node names for multi-node input', async () => {

--- a/packages/core/geometry/src/utils/glb-writer.ts
+++ b/packages/core/geometry/src/utils/glb-writer.ts
@@ -49,6 +49,12 @@ export type GlbPrimitive = {
   extensions?: Record<string, JSONObject>;
 };
 
+/** Exact oriented 2-manifold surface topology retained across render-vertex seams. @public */
+export type GlbManifoldTopology = {
+  /** Triangle indices into the node's shared POSITION accessor. */
+  indices: Uint32Array;
+};
+
 /**
  * A scene node containing one or more mesh primitives.
  *
@@ -57,6 +63,8 @@ export type GlbPrimitive = {
 export type GlbNode = {
   name?: string;
   primitives: GlbPrimitive[];
+  /** Exact topology for a triangle-only surface mesh; the writer validates and serializes `EXT_mesh_manifold`. */
+  manifoldTopology?: GlbManifoldTopology;
   extras?: JSONObject;
   extensions?: Record<string, JSONObject>;
 };
@@ -146,6 +154,7 @@ type GltfJson = {
   meshes: Array<{
     primitives: GltfJsonPrimitive[];
     name?: string;
+    extensions?: Record<string, JSONObject>;
   }>;
   accessors: GltfJsonAccessor[];
   bufferViews: GltfJsonBufferView[];
@@ -174,6 +183,11 @@ type GltfJsonAccessor = {
   type: string;
   min?: number[];
   max?: number[];
+  sparse?: {
+    count: number;
+    indices: { bufferView: number; componentType: number };
+    values: { bufferView: number };
+  };
 };
 
 type GltfJsonBufferView = {
@@ -199,6 +213,138 @@ type GltfJsonMaterial = {
 type BufferEntry = {
   data: Uint8Array<ArrayBuffer>;
   byteOffset: number;
+};
+
+type ValidatedManifoldTopology = {
+  renderIndices: Uint32Array;
+  mergeIndices: Uint32Array;
+  mergeValues: Uint32Array;
+};
+
+const arraysEqual = (left: Float32Array | undefined, right: Float32Array | undefined): boolean =>
+  left === right ||
+  (left?.length === right?.length && left?.every((value, index) => value === right?.[index]) === true);
+
+const validateManifoldTopology = (node: GlbNode): ValidatedManifoldTopology => {
+  const topology = node.manifoldTopology!;
+  const first = node.primitives[0];
+  if (!first || node.primitives.some((primitive) => primitive.mode !== 4)) {
+    throw new Error('manifoldTopology requires one or more TRIANGLES primitives');
+  }
+  if (
+    first.positions.length === 0 ||
+    first.positions.length % 3 !== 0 ||
+    first.positions.some((value) => !Number.isFinite(value)) ||
+    (first.normals?.length ?? first.positions.length) !== first.positions.length ||
+    node.primitives.some((primitive) => primitive.indices.length % 3 !== 0)
+  ) {
+    throw new Error('manifoldTopology requires complete finite triangle attributes and indices');
+  }
+  if (
+    node.primitives.some(
+      (primitive) =>
+        !arraysEqual(primitive.positions, first.positions) || !arraysEqual(primitive.normals, first.normals),
+    )
+  ) {
+    throw new Error('manifoldTopology primitives must share identical POSITION and NORMAL attributes');
+  }
+
+  const renderIndices = new Uint32Array(
+    node.primitives.reduce((count, primitive) => count + primitive.indices.length, 0),
+  );
+  let offset = 0;
+  for (const primitive of node.primitives) {
+    renderIndices.set(primitive.indices, offset);
+    offset += primitive.indices.length;
+  }
+  if (topology.indices.length !== renderIndices.length || topology.indices.length % 3 !== 0) {
+    throw new Error('manifoldTopology and render index streams must contain the same complete triangles');
+  }
+
+  const vertexCount = first.positions.length / 3;
+  const mergeIndices: number[] = [];
+  const mergeValues: number[] = [];
+  const edges = new Map<string, { count: number; winding: number }>();
+  const links = Array.from({ length: vertexCount }, () => [] as Array<[number, number]>);
+  for (let index = 0; index < topology.indices.length; index++) {
+    const vertex = topology.indices[index]!;
+    if (vertex >= vertexCount) {
+      throw new Error('manifoldTopology index out of range');
+    }
+    if (vertex !== renderIndices[index]) {
+      const original = renderIndices[index]!;
+      if (original >= vertexCount) {
+        throw new Error('render index out of range');
+      }
+      const originalOffset = original * 3;
+      const manifoldOffset = vertex * 3;
+      if (
+        first.positions[originalOffset] !== first.positions[manifoldOffset] ||
+        first.positions[originalOffset + 1] !== first.positions[manifoldOffset + 1] ||
+        first.positions[originalOffset + 2] !== first.positions[manifoldOffset + 2]
+      ) {
+        throw new Error('manifoldTopology may merge only vertices with identical POSITION values');
+      }
+      mergeIndices.push(index);
+      mergeValues.push(vertex);
+    }
+  }
+  for (let index = 0; index < topology.indices.length; index += 3) {
+    const triangle = topology.indices.subarray(index, index + 3);
+    if (triangle[0] === triangle[1] || triangle[1] === triangle[2] || triangle[2] === triangle[0]) {
+      throw new Error('manifoldTopology contains a collapsed triangle');
+    }
+    links[triangle[0]!]!.push([triangle[1]!, triangle[2]!]);
+    links[triangle[1]!]!.push([triangle[2]!, triangle[0]!]);
+    links[triangle[2]!]!.push([triangle[0]!, triangle[1]!]);
+    for (const [start, end] of [
+      [triangle[0]!, triangle[1]!],
+      [triangle[1]!, triangle[2]!],
+      [triangle[2]!, triangle[0]!],
+    ] as const) {
+      const key = start < end ? `${start}:${end}` : `${end}:${start}`;
+      const edge = edges.get(key) ?? { count: 0, winding: 0 };
+      edge.count++;
+      edge.winding += start < end ? 1 : -1;
+      edges.set(key, edge);
+    }
+  }
+  if ([...edges.values()].some(({ count, winding }) => count !== 2 || winding !== 0)) {
+    throw new Error('manifoldTopology is not an oriented 2-manifold');
+  }
+  for (const link of links) {
+    if (link.length === 0) {
+      continue;
+    }
+    const adjacency = new Map<number, number[]>();
+    for (const [left, right] of link) {
+      adjacency.set(left, [...(adjacency.get(left) ?? []), right]);
+      adjacency.set(right, [...(adjacency.get(right) ?? []), left]);
+    }
+    if ([...adjacency.values()].some((neighbors) => neighbors.length !== 2)) {
+      throw new Error('manifoldTopology has a non-manifold vertex link');
+    }
+    const start = adjacency.keys().next().value!;
+    const pending = [start];
+    const visited = new Set<number>();
+    while (pending.length > 0) {
+      const vertex = pending.pop()!;
+      if (visited.has(vertex)) {
+        continue;
+      }
+      visited.add(vertex);
+      pending.push(...adjacency.get(vertex)!);
+    }
+    if (visited.size !== adjacency.size) {
+      throw new Error('manifoldTopology has a disconnected vertex link');
+    }
+  }
+
+  return {
+    renderIndices,
+    mergeIndices: Uint32Array.from(mergeIndices),
+    mergeValues: Uint32Array.from(mergeValues),
+  };
 };
 
 /**
@@ -295,8 +441,104 @@ function buildGltf(input: GlbInput): { json: GltfJson; binBuffer: Uint8Array<Arr
 
   for (const node of input.nodes) {
     const primitiveJsons: GltfJsonPrimitive[] = [];
+    let meshExtensions: Record<string, JSONObject> | undefined;
 
-    for (const primitive of node.primitives) {
+    if (node.manifoldTopology) {
+      const { renderIndices, mergeIndices, mergeValues } = validateManifoldTopology(node);
+      const first = node.primitives[0]!;
+      const positionViewIndex = addBufferView(first.positions, targetArrayBuffer);
+      const { min, max } = computeMinMax(first.positions);
+      const positionAccessorIndex = accessors.length;
+      accessors.push({
+        bufferView: positionViewIndex,
+        byteOffset: 0,
+        componentType: componentTypeFloat,
+        count: first.positions.length / 3,
+        type: 'VEC3',
+        min,
+        max,
+      });
+      const attributes: Record<string, number> = {};
+      attributes['POSITION'] = positionAccessorIndex;
+      if (first.normals && first.normals.length > 0) {
+        const normalViewIndex = addBufferView(first.normals, targetArrayBuffer);
+        const normalAccessorIndex = accessors.length;
+        accessors.push({
+          bufferView: normalViewIndex,
+          byteOffset: 0,
+          componentType: componentTypeFloat,
+          count: first.normals.length / 3,
+          type: 'VEC3',
+        });
+        attributes['NORMAL'] = normalAccessorIndex;
+      }
+      const indexViewIndex = addBufferView(renderIndices, targetElementArrayBuffer);
+      let indexOffset = 0;
+      for (const primitive of node.primitives) {
+        const indexAccessorIndex = accessors.length;
+        accessors.push({
+          bufferView: indexViewIndex,
+          byteOffset: indexOffset * Uint32Array.BYTES_PER_ELEMENT,
+          componentType: componentTypeUnsignedInt,
+          count: primitive.indices.length,
+          type: 'SCALAR',
+        });
+        indexOffset += primitive.indices.length;
+        primitiveJsons.push({
+          attributes,
+          mode: primitive.mode,
+          material: getOrCreateMaterial(primitive.material),
+          indices: indexAccessorIndex,
+          ...(primitive.extras ? { extras: primitive.extras } : {}),
+          ...(primitive.extensions ? { extensions: primitive.extensions } : {}),
+        });
+      }
+      const manifoldAccessorIndex = accessors.length;
+      const manifoldAccessor: GltfJsonAccessor = {
+        bufferView: indexViewIndex,
+        byteOffset: 0,
+        componentType: componentTypeUnsignedInt,
+        count: node.manifoldTopology.indices.length,
+        type: 'SCALAR',
+      };
+      accessors.push(manifoldAccessor);
+      const manifoldAttributes: JSONObject = {};
+      manifoldAttributes['POSITION'] = positionAccessorIndex;
+      const extension: JSONObject = {
+        manifoldPrimitive: { attributes: manifoldAttributes, indices: manifoldAccessorIndex, mode: 4 },
+      };
+      if (mergeIndices.length > 0) {
+        const mergeIndexView = addBufferView(mergeIndices);
+        const mergeValueView = addBufferView(mergeValues);
+        const mergeIndexAccessor = accessors.length;
+        accessors.push({
+          bufferView: mergeIndexView,
+          byteOffset: 0,
+          componentType: componentTypeUnsignedInt,
+          count: mergeIndices.length,
+          type: 'SCALAR',
+        });
+        const mergeValueAccessor = accessors.length;
+        accessors.push({
+          bufferView: mergeValueView,
+          byteOffset: 0,
+          componentType: componentTypeUnsignedInt,
+          count: mergeValues.length,
+          type: 'SCALAR',
+        });
+        manifoldAccessor.sparse = {
+          count: mergeIndices.length,
+          indices: { bufferView: mergeIndexView, componentType: componentTypeUnsignedInt },
+          values: { bufferView: mergeValueView },
+        };
+        extension['mergeIndices'] = mergeIndexAccessor;
+        extension['mergeValues'] = mergeValueAccessor;
+      }
+      meshExtensions = {};
+      meshExtensions['EXT_mesh_manifold'] = extension;
+    }
+
+    for (const primitive of node.manifoldTopology ? [] : node.primitives) {
       const materialIndex = getOrCreateMaterial(primitive.material);
 
       const positionViewIndex = addBufferView(primitive.positions, targetArrayBuffer);
@@ -353,6 +595,7 @@ function buildGltf(input: GlbInput): { json: GltfJson; binBuffer: Uint8Array<Arr
       meshes.push({
         primitives: primitiveJsons,
         ...(node.name ? { name: node.name } : {}),
+        ...(meshExtensions ? { extensions: meshExtensions } : {}),
       });
 
       const nodeIndex = nodes.length;
@@ -403,8 +646,11 @@ function buildGltf(input: GlbInput): { json: GltfJson; binBuffer: Uint8Array<Arr
       typeof input.extensions === 'function' ? input.extensions(extraBufferViewIndices) : input.extensions;
   }
 
-  if (input.extensionsUsed && input.extensionsUsed.length > 0) {
-    json.extensionsUsed = [...new Set(input.extensionsUsed)];
+  const extensionsUsed = input.nodes.some((node) => node.manifoldTopology)
+    ? [...(input.extensionsUsed ?? []), 'EXT_mesh_manifold']
+    : input.extensionsUsed;
+  if (extensionsUsed && extensionsUsed.length > 0) {
+    json.extensionsUsed = [...new Set(extensionsUsed)];
   }
 
   if (input.extensionsRequired && input.extensionsRequired.length > 0) {

--- a/packages/core/geometry/src/utils/gltf-geometry-name-normalizer.test.ts
+++ b/packages/core/geometry/src/utils/gltf-geometry-name-normalizer.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { NodeIO } from '@gltf-transform/core';
+import { Accessor, Document, NodeIO, Primitive } from '@gltf-transform/core';
 import type { JSONDocument } from '@gltf-transform/core';
+import { EXTManifold } from 'manifold-3d/manifold-gltf';
 
 import { normalizeGltfGeometryNames } from '#utils/gltf-geometry-name-normalizer.js';
+import { transformGltfExportBytes } from '#utils/gltf-export-transform.js';
 import { writeGlb, writeGltfJson } from '#utils/glb-writer.js';
 import type { GlbInput, GlbPrimitive } from '#utils/glb-writer.js';
 
@@ -50,6 +52,47 @@ const withSceneName = async (bytes: Uint8Array<ArrayBuffer>, sceneName: string):
   const document = await io.readBinary(bytes);
   document.getRoot().listScenes()[0]!.setName(sceneName);
   return io.writeBinary(document);
+};
+
+const createManifoldGlb = async (): Promise<Uint8Array<ArrayBuffer>> => {
+  const document = new Document();
+  const buffer = document.createBuffer();
+  const positions = document
+    .createAccessor('positions')
+    .setBuffer(buffer)
+    .setType(Accessor.Type['VEC3']!)
+    .setArray(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]));
+  const primitive = document
+    .createPrimitive()
+    .setMode(Primitive.Mode['TRIANGLES']!)
+    .setAttribute('POSITION', positions)
+    .setIndices(
+      document
+        .createAccessor('render indices')
+        .setBuffer(buffer)
+        .setType(Accessor.Type['SCALAR']!)
+        .setArray(new Uint32Array([0, 2, 1, 0, 1, 3, 1, 2, 3, 2, 0, 3])),
+    );
+  const mesh = document.createMesh('Tetrahedron').addPrimitive(primitive);
+  const manifold = document.createExtension(EXTManifold).createManifoldPrimitive();
+  manifold
+    .setIndices(
+      document
+        .createAccessor('manifold indices')
+        .setBuffer(buffer)
+        .setType(Accessor.Type['SCALAR']!)
+        .setArray(new Uint32Array([0, 2, 1, 0, 1, 3, 1, 2, 3, 2, 0, 3])),
+    )
+    .setRunIndex([0, 12]);
+  mesh.setExtension(EXTManifold.EXTENSION_NAME, manifold);
+  document.createScene().addChild(document.createNode('Tetrahedron').setMesh(mesh));
+  return new NodeIO().registerExtensions([EXTManifold]).writeBinary(document);
+};
+
+const readGlbJson = (bytes: Uint8Array<ArrayBuffer>): JSONDocument['json'] => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const length = view.getUint32(12, true);
+  return JSON.parse(new TextDecoder().decode(bytes.subarray(20, 20 + length))) as JSONDocument['json'];
 };
 
 describe('normalizeGltfGeometryNames', () => {
@@ -141,5 +184,29 @@ describe('normalizeGltfGeometryNames', () => {
     expect(document.getRoot().listNodes()[0]!.getName()).toBe('Shape 1');
     expect(document.getRoot().listMeshes()[0]!.getName()).toBe('Shape 1');
     expect(document.getRoot().listMaterials()[0]!.getName()).toBe('');
+  });
+
+  it('should preserve EXT_mesh_manifold while normalizing names', async () => {
+    const normalized = await normalizeGltfGeometryNames(await createManifoldGlb(), { format: 'glb' });
+    const json = readGlbJson(normalized);
+
+    expect(json.extensionsUsed).toContain('EXT_mesh_manifold');
+    expect(json.meshes?.[0]?.extensions?.['EXT_mesh_manifold']).toMatchObject({
+      manifoldPrimitive: { mode: Primitive.Mode['TRIANGLES'] },
+    });
+  });
+
+  it('should preserve EXT_mesh_manifold while transforming an export', async () => {
+    const transformed = await transformGltfExportBytes(await createManifoldGlb(), {
+      format: 'glb',
+      coordinateSystem: 'z-up',
+      unit: { length: 'millimeter' },
+    });
+    const json = readGlbJson(transformed);
+
+    expect(json.extensionsUsed).toContain('EXT_mesh_manifold');
+    expect(json.meshes?.[0]?.extensions?.['EXT_mesh_manifold']).toMatchObject({
+      manifoldPrimitive: { mode: Primitive.Mode['TRIANGLES'] },
+    });
   });
 });

--- a/packages/plugins/manifold/src/manifold.kernel.test.ts
+++ b/packages/plugins/manifold/src/manifold.kernel.test.ts
@@ -78,6 +78,12 @@ const extractGltfBytes = (result: { data: GeometryResponse }): Uint8Array<ArrayB
   return result.data.content;
 };
 
+const readGlbJson = (bytes: Uint8Array<ArrayBuffer>): Record<string, unknown> => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const jsonLength = view.getUint32(12, true);
+  return JSON.parse(new TextDecoder().decode(bytes.subarray(20, 20 + jsonLength))) as Record<string, unknown>;
+};
+
 describe('ManifoldWorker', () => {
   describe('getParameters', () => {
     it('should extract defaultParams from ESM module', async () => {
@@ -168,6 +174,11 @@ describe('ManifoldWorker', () => {
       await geometryHelpers.expectMeshCount(result, 1);
       await geometryHelpers.expectBoundingBoxSize(result, [0.01, 0.01, 0.01], 0.0005);
       if (result.success) {
+        const json = readGlbJson(extractGltfBytes(result));
+        expect(json['extensionsUsed']).toContain('EXT_mesh_manifold');
+        expect(json['meshes']?.[0]?.['extensions']?.['EXT_mesh_manifold']).toMatchObject({
+          manifoldPrimitive: { mode: 4 },
+        });
         const { nodeNames, meshNames } = await readGltfNodeMeshNames(extractGltfBytes(result));
         expect(nodeNames).toEqual(['Shape 1']);
         expect(meshNames).toEqual(['Shape 1']);

--- a/packages/plugins/middleware/package.json
+++ b/packages/plugins/middleware/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@taucad/runtime": "workspace:*",
     "@taucad/runtime-testing": "workspace:*",
+    "manifold-3d": "catalog:",
     "zod": "catalog:"
   },
   "taucad": {

--- a/packages/plugins/middleware/src/gltf-edge-detection.middleware.test.ts
+++ b/packages/plugins/middleware/src/gltf-edge-detection.middleware.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { Document, NodeIO, Accessor } from '@gltf-transform/core';
 import { KHRMaterialsUnlit } from '@gltf-transform/extensions';
+import { EXTManifold } from 'manifold-3d/manifold-gltf';
 import type { GeometryGltf, GeometrySvg, ExportGeometryResult } from '@taucad/runtime/types';
 import type { KernelMiddlewareRuntime } from '@taucad/runtime/middleware';
 
@@ -38,8 +39,8 @@ const removedEdgeBundleNodeName = ['tau', 'merged', 'edges'].join('-');
  *
  * @returns The binary GLTF data
  */
-async function createCubeGltfWithoutLines(): Promise<Uint8Array<ArrayBuffer>> {
-  const io = new NodeIO();
+async function createCubeGltfWithoutLines(manifold = false): Promise<Uint8Array<ArrayBuffer>> {
+  const io = manifold ? new NodeIO().registerExtensions([EXTManifold]) : new NodeIO();
   const document = new Document();
   const buffer = document.createBuffer();
 
@@ -74,7 +75,7 @@ async function createCubeGltfWithoutLines(): Promise<Uint8Array<ArrayBuffer>> {
 
   // 12 triangles for 6 faces
   // prettier-ignore -- preserve triangle index grouping
-  const indices = new Uint16Array([
+  const indices = new Uint32Array([
     0,
     1,
     2,
@@ -135,7 +136,15 @@ async function createCubeGltfWithoutLines(): Promise<Uint8Array<ArrayBuffer>> {
     .setIndices(indexAccessor);
 
   const mesh = document.createMesh().addPrimitive(primitive);
-  const node = document.createNode().setMesh(mesh);
+  if (manifold) {
+    const topology = document
+      .createExtension(EXTManifold)
+      .createManifoldPrimitive()
+      .setIndices(indexAccessor)
+      .setRunIndex([0, indices.length]);
+    mesh.setExtension(EXTManifold.EXTENSION_NAME, topology);
+  }
+  const node = document.createNode().setMesh(mesh).setExtras({ tauComponentId: 'cube' });
   document.createScene().addChild(node);
 
   return io.writeBinary(document);
@@ -487,6 +496,36 @@ describe('gltfEdgeDetection', () => {
           // The content should be different from the original (re-serialized with generated edges).
           expect(geometry.content).not.toBe(gltfData);
           expect(geometry.content.byteLength).toBeGreaterThan(gltfData.byteLength);
+        }
+      });
+
+      it('should preserve manifold surfaces and attach generated lines as an identity child', async () => {
+        const gltfData = await createCubeGltfWithoutLines(true);
+        const handlerResult = createSuccessResult({ format: 'gltf', content: gltfData });
+        const { input, runtime } = createEdgeDetectionContext();
+        const result = await gltfEdgeDetectionDefinition.wrapCreateGeometry!(
+          input,
+          createMockCreateGeometryHandler(handlerResult),
+          runtime,
+        );
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          const io = new NodeIO().registerExtensions([KHRMaterialsUnlit, EXTManifold]);
+          const document = await io.readBinary((result.data as GeometryGltf).content);
+          const [surface, edges] = document.getRoot().listMeshes();
+          const surfaceNode = document
+            .getRoot()
+            .listNodes()
+            .find((node) => node.getMesh() === surface)!;
+          const edgeNode = surfaceNode.listChildren().find((node) => node.getMesh() === edges)!;
+
+          expect(surface!.listPrimitives().map((primitive) => primitive.getMode())).toEqual([primitiveModeTriangles]);
+          expect(surface!.getExtension(EXTManifold.EXTENSION_NAME)).not.toBeNull();
+          expect(edges!.listPrimitives().map((primitive) => primitive.getMode())).toEqual([primitiveModeLines]);
+          expect(edges!.getExtension(EXTManifold.EXTENSION_NAME)).toBeNull();
+          expect(edgeNode.getMatrix()).toEqual([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+          expect(edgeNode.getExtras()).toMatchObject({ tauComponentId: 'cube' });
         }
       });
     });

--- a/packages/plugins/middleware/src/gltf-edge-detection.middleware.ts
+++ b/packages/plugins/middleware/src/gltf-edge-detection.middleware.ts
@@ -50,8 +50,9 @@ function addEdgePrimitivesToDocument(document: Document, thresholdDegrees: numbe
     return edgeMaterial;
   }
 
-  // Process each mesh
-  for (const mesh of document.getRoot().listMeshes()) {
+  // Process each source mesh. Newly created sibling edge meshes are not inputs.
+  const sourceMeshes = document.getRoot().listMeshes();
+  for (const mesh of sourceMeshes) {
     const primitivesToAdd: Primitive[] = [];
 
     for (const primitive of mesh.listPrimitives()) {
@@ -104,11 +105,32 @@ function addEdgePrimitivesToDocument(document: Document, thresholdDegrees: numbe
       primitivesToAdd.push(edgePrimitive);
     }
 
-    // Add edge primitives to mesh
-    for (const edgePrimitive of primitivesToAdd) {
-      mesh.addPrimitive(edgePrimitive);
-      edgesAdded = true;
+    if (primitivesToAdd.length === 0) {
+      continue;
     }
+
+    if (mesh.getExtension('EXT_mesh_manifold')) {
+      const edgeMesh = document.createMesh(`${mesh.getName() || 'mesh'} edges`);
+      for (const edgePrimitive of primitivesToAdd) {
+        edgeMesh.addPrimitive(edgePrimitive);
+      }
+      for (const node of document
+        .getRoot()
+        .listNodes()
+        .filter((candidate) => candidate.getMesh() === mesh)) {
+        node.addChild(
+          document
+            .createNode(`${node.getName() || mesh.getName() || 'mesh'} edges`)
+            .setMesh(edgeMesh)
+            .setExtras({ ...node.getExtras() }),
+        );
+      }
+    } else {
+      for (const edgePrimitive of primitivesToAdd) {
+        mesh.addPrimitive(edgePrimitive);
+      }
+    }
+    edgesAdded = true;
   }
 
   return edgesAdded;
@@ -117,9 +139,10 @@ function addEdgePrimitivesToDocument(document: Document, thresholdDegrees: numbe
 /**
  * Add edge primitives to a GLTF geometry while preserving component ownership.
  *
- * Generated LINES primitives are appended to the same mesh as their source
- * TRIANGLES primitive. Existing LINES primitives remain in place, because they
- * usually come from native CAD topology and already belong to their source mesh.
+ * Generated LINES primitives are appended to the source mesh unless that mesh
+ * carries `EXT_mesh_manifold`. Annotated surface meshes keep TRIANGLES only;
+ * their lines use an identity child node so component visibility and transforms
+ * remain shared without invalidating the topology extension.
  *
  * If no triangle meshes need generated edges, the original geometry is returned
  * unchanged to skip the @gltf-transform re-serialisation roundtrip.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2603,6 +2603,9 @@ importers:
       '@gltf-transform/functions':
         specifier: 'catalog:'
         version: 4.4.0
+      manifold-3d:
+        specifier: 'catalog:'
+        version: 3.4.1(@gltf-transform/core@4.4.0)(@gltf-transform/extensions@4.4.0)(@gltf-transform/functions@4.4.0)(esbuild-wasm@0.27.7)
     devDependencies:
       '@taucad/runtime':
         specifier: workspace:*
@@ -2905,6 +2908,9 @@ importers:
       '@taucad/runtime-testing':
         specifier: workspace:*
         version: link:../../runtime-testing
+      manifold-3d:
+        specifier: 'catalog:'
+        version: 3.4.1(@gltf-transform/core@4.4.0)(@gltf-transform/extensions@4.4.0)(@gltf-transform/functions@4.4.0)(esbuild-wasm@0.27.7)
       zod:
         specifier: 'catalog:'
         version: 4.4.3


### PR DESCRIPTION
## Summary

- register the existing `manifold-3d/manifold-gltf` extension implementation in Tau glTF-Transform mutation paths
- add a typed, validated `GlbManifoldTopology` input that emits compliant shared accessors, material runs, sparse merge data, and `extensionsUsed`
- keep generated line primitives in sibling meshes when a surface carries `EXT_mesh_manifold`
- prove the Manifold kernel emits the extension and normalization/export transforms preserve it

This independent Tau adapter targets `geospec`; nanoraster PR #61 remains stacked on its section-rendering prerequisite. Tau acceptance uses the locally packed nanoraster tarball before publication.

## Verification

- local `nanoraster-0.4.1.tgz` installed; its WASM hash matches the P1 build
- geometry-core: 80 tests pass and typecheck passes on current `geospec`
- image: 52 tests pass through the final tarball before the base refresh
- geometry-core, middleware, and Manifold lint passes; existing warnings remain warnings
- the prior stacked-base release-plan check passed

## Base status

The remote `geospec` base currently cannot install because `apps/ui` references a missing `@taucad/billing` workspace package. With the existing dependency tree, middleware still stops at the base branch missing `exportFidelityValues` runtime constant, and Manifold stops at the base branch missing `@taucad/bundler-core` package link. Geometry-core reaches and passes this P1 code. No unrelated base compatibility shim is included here.

## AI disclosure

This pull request was prepared with assistance from OpenAI Codex (GPT-5). I reviewed and verified the changes and test results.

